### PR TITLE
Locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sleep 3
 install:
   - sudo apt-get install python-tk python3-tk
-  - python -m pip install nose coverage codecov psutil pynput
+  - python -m pip install nose coverage codecov psutil pynput babel
 script:
   - python -m pip install .
   - python -m nose --with-coverage

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,7 @@ Changelog
 ---------
 
 - tkfilebrowser 2.1.2
+    * Use babel instead of locale in order not to change the locale globally
     * Speed up (a little) folder content display
 
 - tkfilebrowser 2.1.1

--- a/changelog
+++ b/changelog
@@ -6,6 +6,7 @@ Changelog
 ---------
 
 - tkfilebrowser 2.1.2
+    * Use babel instead of locale in order not to change the locale globally
     * Speed up (a little) folder content display
     
 - tkfilebrowser 2.1.1

--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,4 @@ setup(name='tkfilebrowser',
       keywords=['tkinter', 'filedialog', 'filebrowser'],
       packages=["tkfilebrowser"],
       package_data={"tkfilebrowser": ["images/*"]},
-      requires=["os", "locale", "time", "psutil", "tkinter", "math", "urllib"])
+      requires=["os", "locale", "time", "psutil", "tkinter", "math", "urllib", "babel"])

--- a/tkfilebrowser/constants.py
+++ b/tkfilebrowser/constants.py
@@ -25,9 +25,11 @@ Copyright 2007-2013 elementary LLC.
 Constants and functions
 """
 
-
+print('ok')
 import locale
-import time
+from babel.numbers import format_number
+from babel.dates import format_date, format_datetime
+from datetime import datetime
 import os
 from math import log, floor
 
@@ -73,7 +75,7 @@ IM_RECENT_24 = os.path.join(PATH, "images", "recent_24.png")
 
 
 # ---  translation
-lang = locale.getdefaultlocale()[0][:2]
+LANG = locale.getdefaultlocale()[0]
 
 EN = {}
 FR = {"B": "octets", "MB": "Mo", "kB": "ko", "GB": "Go", "TB": "To",
@@ -86,7 +88,7 @@ FR = {"B": "octets", "MB": "Mo", "kB": "ko", "GB": "Go", "TB": "To",
       "Shortcuts": "Raccourcis", "Save As": "Enregistrer sous",
       "Recent": "Récents", "Recently used": "Récemment utilisés"}
 LANGUAGES = {"fr": FR, "en": EN}
-if lang == "fr":
+if LANG[:2] == "fr":
     TR = LANGUAGES["fr"]
 else:
     TR = LANGUAGES["en"]
@@ -97,13 +99,27 @@ def _(text):
     return TR.get(text, text)
 
 
+fromtimestamp = datetime.fromtimestamp
+
+
+def locale_date(date=None):
+    return format_date(date, 'short', locale=LANG)
+
+
+def locale_datetime(date=None):
+    return format_datetime(date, 'EEEE HH:mm', locale=LANG)
+
+
+def locale_number(nb):
+    return format_number(nb, locale=LANG)
+
+
 SIZES = [_("B"), _("kB"), _("MB"), _("GB"), _("TB")]
 
 # ---  locale settings for dates
-locale.setlocale(locale.LC_ALL, "")
-TODAY = time.strftime("%x")
-YEAR = time.strftime("%Y")
-DAY = int(time.strftime("%j"))
+TODAY = locale_date()
+YEAR = datetime.now().year
+DAY = int(format_date(None, 'D', locale=LANG))
 
 
 # ---  functions
@@ -137,12 +153,12 @@ def remove_trace(variable, mode, cbname):
 
 def get_modification_date(file):
     """Return the modification date of file."""
-    tps = time.localtime(os.path.getmtime(file))
-    date = time.strftime("%x", tps)
+    tps = fromtimestamp(os.path.getmtime(file))
+    date = locale_date(tps)
     if date == TODAY:
-        date = _("Today") + time.strftime(" %H:%M", tps)
-    elif time.strftime("%Y", tps) == YEAR and (DAY - int(time.strftime("%j", tps))) < 7:
-        date = time.strftime("%A %H:%M", tps)
+        date = _("Today") + tps.strftime(" %H:%M")
+    elif tps.year == YEAR and (DAY - int(tps.strftime("%j"))) < 7:
+        date = locale_datetime(tps)
     return date
 
 
@@ -157,20 +173,20 @@ def get_size(file):
         else:
             unit = SIZES[-1]
             s = size_o / (1024**(len(SIZES) - 1))
-        size = "%s %s" % (locale.format("%.1f", s), unit)
+        size = "%s %s" % (locale_number("%.1f" % s), unit)
     else:
         size = "0 " + _("B")
     return size
 
 
 def display_modification_date(mtime):
-    """Return the modification date of file."""
-    tps = time.localtime(mtime)
-    date = time.strftime("%x", tps)
+    """Return the modDification date of file."""
+    tps = fromtimestamp(mtime)
+    date = locale_date(tps)
     if date == TODAY:
-        date = _("Today") + time.strftime(" %H:%M", tps)
-    elif time.strftime("%Y", tps) == YEAR and (DAY - int(time.strftime("%j", tps))) < 7:
-        date = time.strftime("%A %H:%M", tps)
+        date = _("Today") + tps.strftime(" %H:%M")
+    elif tps.year == YEAR and (DAY - int(tps.strftime("%j"))) < 7:
+        date = locale_datetime(tps)
     return date
 
 
@@ -184,7 +200,7 @@ def display_size(size_o):
         else:
             unit = SIZES[-1]
             s = size_o / (1024**(len(SIZES) - 1))
-        size = "%s %s" % (locale.format("%.1f", s), unit)
+        size = "%s %s" % (locale_number("%.1f" % s), unit)
     else:
         size = "0 " + _("B")
     return size
@@ -192,4 +208,3 @@ def display_size(size_o):
 
 def key_sort_files(file):
     return file.is_file(), file.name.lower()
-

--- a/tkfilebrowser/constants.py
+++ b/tkfilebrowser/constants.py
@@ -25,7 +25,6 @@ Copyright 2007-2013 elementary LLC.
 Constants and functions
 """
 
-print('ok')
 import locale
 from babel.numbers import format_number
 from babel.dates import format_date, format_datetime

--- a/tkfilebrowser/filebrowser.py
+++ b/tkfilebrowser/filebrowser.py
@@ -23,8 +23,8 @@ Main class
 
 import psutil
 from os import walk, mkdir
-from os.path import exists, join, getmtime, realpath, split, expanduser, abspath
-from os.path import isabs, splitext, dirname, getsize, isdir, isfile, islink
+from os.path import exists, join, getmtime, realpath, split, expanduser, \
+    abspath, isabs, splitext, dirname, getsize, isdir, isfile, islink
 try:
     from os import scandir
     SCANDIR = True
@@ -32,16 +32,14 @@ except ImportError:
     SCANDIR = False
 import traceback
 import tkfilebrowser.constants as cst
+from tkfilebrowser.constants import unquote, tk, ttk, key_sort_files, \
+    get_modification_date, get_size
 from tkfilebrowser.autoscrollbar import AutoScrollbar
 from tkfilebrowser.path_button import PathButton
 from tkfilebrowser.tooltip import TooltipTreeWrapper
 from tkfilebrowser.recent_files import RecentFiles
 
 _ = cst._
-unquote = cst.unquote
-tk = cst.tk
-ttk = cst.ttk
-key_sort_files = cst.key_sort_files
 
 
 class FileBrowser(tk.Toplevel):
@@ -669,7 +667,7 @@ class FileBrowser(tk.Toplevel):
                         tags.append("folder_link")
                     else:
                         tags.append("folder")
-                    vals = (p, "", cst.get_modification_date(p))
+                    vals = (p, "", get_modification_date(p))
                 if vals and p not in paths:
                     i += 1
                     paths.append(p)
@@ -690,18 +688,18 @@ class FileBrowser(tk.Toplevel):
                         ext = splitext(f)[-1]
                         if extension == [""] or ext in extension:
                             tags.append("file_link")
-                            vals = (p, cst.get_size(p), cst.get_modification_date(p))
+                            vals = (p, get_size(p), get_modification_date(p))
                     elif isdir(p):
                         tags.append("folder_link")
-                        vals = (p, "", cst.get_modification_date(p))
+                        vals = (p, "", get_modification_date(p))
                 elif isfile(p):
                     ext = splitext(f)[-1]
                     if extension == [""] or ext in extension:
                         tags.append("file")
-                        vals = (p, cst.get_size(p), cst.get_modification_date(p))
+                        vals = (p, get_size(p), get_modification_date(p))
                 elif isdir(p):
                     tags.append("folder")
-                    vals = (p, "", cst.get_modification_date(p))
+                    vals = (p, "", get_modification_date(p))
                 if vals:
                     i += 1
                     self.right_tree.insert("", "end", p, text=f, tags=tags,
@@ -940,7 +938,7 @@ class FileBrowser(tk.Toplevel):
                     tags = tags + (str(i % 2),)
                     i += 1
                 self.right_tree.insert("", "end", p, text=d, tags=tags,
-                                       values=("", "", cst.get_modification_date(p)))
+                                       values=("", "", get_modification_date(p)))
             # display files
             files.sort(key=lambda n: n.lower())
             extension = self.filetypes[self.filetype.get()]
@@ -961,8 +959,8 @@ class FileBrowser(tk.Toplevel):
                         i += 1
 
                     self.right_tree.insert("", "end", p, text=f, tags=tags,
-                                           values=("", cst.get_size(p),
-                                                   cst.get_modification_date(p)))
+                                           values=("", get_size(p),
+                                                   get_modification_date(p)))
             else:
                 for f in files:
                     ext = splitext(f)[-1]
@@ -982,8 +980,8 @@ class FileBrowser(tk.Toplevel):
                             i += 1
 
                         self.right_tree.insert("", "end", p, text=f, tags=tags,
-                                               values=("", cst.get_size(p),
-                                                       cst.get_modification_date(p)))
+                                               values=("", get_size(p),
+                                                       get_modification_date(p)))
             items = self.right_tree.get_children("")
             if items:
                 self.right_tree.focus_set()


### PR DESCRIPTION
Replace `locale.setlocale` that changed the locale globally (therefore also for the python program importing the module) by `babel` module to format numbers and dates depending on the default locale.