### PR TITLE
Fix #9:  ValueError raised by after_cancel in Python 3.6.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,9 @@ Documentation
 Changelog
 ---------
 
+- tkfilebrowser 2.2.1
+    * Fix ValueError in after_cancel with Python 3.6.5
+
 - tkfilebrowser 2.2.0
     * Use babel instead of locale in order not to change the locale globally
     * Speed up (a little) folder content display

--- a/changelog
+++ b/changelog
@@ -6,6 +6,9 @@ Copyright 2017 Juliette Monsel <j_4321@protonmail.com>
 Changelog
 ---------
 
+- tkfilebrowser 2.2.1
+    * Fix ValueError in after_cancel with Python 3.6.5
+
 - tkfilebrowser 2.2.0
     * Use babel instead of locale in order not to change the locale globally
     * Speed up (a little) folder content display

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='tkfilebrowser',
-      version='2.2.0',
+      version='2.2.1',
       description='File browser for Tkinter, alternative to tkinter.filedialog in linux with GTK bookmarks support.',
       long_description=long_description,
       url='https://github.com/j4321/tkFileBrowser',

--- a/tkfilebrowser/tooltip.py
+++ b/tkfilebrowser/tooltip.py
@@ -101,7 +101,14 @@ class TooltipTreeWrapper:
         self.current_item = None
 
         self.tree.bind('<Motion>', self._on_motion)
-        self.tree.bind('<Leave>', lambda e: self.tree.after_cancel(self._timer_id))
+        self.tree.bind('<Leave>', self._on_leave)
+
+    def _on_leave(self, event):
+        try:
+            self.tree.after_cancel(self._timer_id)
+        except ValueError:
+            # nothing to cancel
+            pass
 
     def add_tooltip(self, item, text):
         """Add a tooltip with given text to the item."""
@@ -116,7 +123,11 @@ class TooltipTreeWrapper:
                     self.tooltip.withdraw()
                     self.current_item = None
         else:
-            self.tree.after_cancel(self._timer_id)
+            try:
+                self.tree.after_cancel(self._timer_id)
+            except ValueError:
+                # nothing to cancel
+                pass
             self._timer_id = self.tree.after(self.delay, self.display_tooltip)
 
     def display_tooltip(self):


### PR DESCRIPTION
Fix #9 by putting `after_cancel` in try/except block to catch the `ValueError` which is raised since Python 3.6.5 if there is nothing to cancel.