### PR TITLE
Avoid warning related to locale.getdefaultlocale deprecation

### DIFF
--- a/tkfilebrowser/constants.py
+++ b/tkfilebrowser/constants.py
@@ -83,24 +83,29 @@ class _different_locale:
     def __init__(self, _locale):
         self.locale = _locale
         self.oldlocale = None
+        try:
+            self.category = locale.LC_MESSAGES
+        except AttributeError:
+            # LC_MESSAGES may not be available on non-POSIX OSes
+            self.category = locale.LC_ALL
 
     def __enter__(self):
-        self.oldlocale = locale.setlocale(locale.LC_MESSAGES, None)
-        locale.setlocale(locale.LC_MESSAGES, self.locale)
+        self.oldlocale = locale.setlocale(self.category, None)
+        locale.setlocale(self.category, self.locale)
 
     def __exit__(self, *args):
         if self.oldlocale is None:
             return
-        locale.setlocale(locale.LC_MESSAGES, self.oldlocale)
+        locale.setlocale(self.category, self.oldlocale)
 
 
 def _getdefaultlocale():
-    _locale = locale.setlocale(locale.LC_MESSAGES, None)
+    _locale = locale.setlocale(self.category, None)
     if _locale == 'C':
         with _different_locale(''):
             # The LC_MESSAGES locale does not seem to be configured:
             # get the user preferred locale.
-            _locale = locale.setlocale(locale.LC_MESSAGES, None)
+            _locale = locale.setlocale(self.category, None)
     return _locale.split('.')
 
 

--- a/tkfilebrowser/constants.py
+++ b/tkfilebrowser/constants.py
@@ -112,13 +112,20 @@ def _getdefaultlocale():
             # The LC_MESSAGES locale does not seem to be configured:
             # get the user preferred locale.
             _locale = locale.setlocale(category, None)
-    return _locale.split('.')
+    lang = _locale.split('.')[0]
+    if len(lang) > 2 and lang[2] != '_':
+        lang = lang[:2]
+
+    from babel import Locale
+    from babel.core import UnknownLocaleError
+    try:
+        babel_locale = Locale.parse(lang)
+    except UnknownLocaleError:
+        babel_locale = Locale.parse('en')
+    return babel_locale
 
 
-try:
-    LANG = _getdefaultlocale()[0]
-except ValueError:
-    LANG = 'en'
+LOCALE = _getdefaultlocale()
 
 EN = {}
 FR = {"B": "octets", "MB": "Mo", "kB": "ko", "GB": "Go", "TB": "To",
@@ -131,8 +138,8 @@ FR = {"B": "octets", "MB": "Mo", "kB": "ko", "GB": "Go", "TB": "To",
       "Shortcuts": "Raccourcis", "Save As": "Enregistrer sous",
       "Recent": "Récents", "Recently used": "Récemment utilisés"}
 LANGUAGES = {"fr": FR, "en": EN}
-if LANG[:2] == "fr":
-    TR = LANGUAGES["fr"]
+if LOCALE.language in LANGUAGES:
+    TR = LANGUAGES[LOCALE.language]
 else:
     TR = LANGUAGES["en"]
 
@@ -146,15 +153,15 @@ fromtimestamp = datetime.fromtimestamp
 
 
 def locale_date(date=None):
-    return format_date(date, 'short', locale=LANG)
+    return format_date(date, 'short', locale=LOCALE)
 
 
 def locale_datetime(date=None):
-    return format_datetime(date, 'EEEE HH:mm', locale=LANG)
+    return format_datetime(date, 'EEEE HH:mm', locale=LOCALE)
 
 
 def locale_number(nb):
-    return format_number(nb, locale=LANG)
+    return format_number(nb, locale=LOCALE)
 
 
 SIZES = [_("B"), _("kB"), _("MB"), _("GB"), _("TB")]
@@ -162,7 +169,7 @@ SIZES = [_("B"), _("kB"), _("MB"), _("GB"), _("TB")]
 # ---  locale settings for dates
 TODAY = locale_date()
 YEAR = datetime.now().year
-DAY = int(format_date(None, 'D', locale=LANG))
+DAY = int(format_date(None, 'D', locale=LOCALE))
 
 
 # ---  functions

--- a/tkfilebrowser/constants.py
+++ b/tkfilebrowser/constants.py
@@ -79,8 +79,33 @@ IM_RECENT = os.path.join(PATH, "images", "recent.png")
 IM_RECENT_24 = os.path.join(PATH, "images", "recent_24.png")
 
 # ---  translation
+class _different_locale:
+    def __init__(self, _locale):
+        self.locale = _locale
+        self.oldlocale = None
+
+    def __enter__(self):
+        self.oldlocale = locale.setlocale(locale.LC_MESSAGES, None)
+        locale.setlocale(locale.LC_MESSAGES, self.locale)
+
+    def __exit__(self, *args):
+        if self.oldlocale is None:
+            return
+        locale.setlocale(locale.LC_MESSAGES, self.oldlocale)
+
+
+def _getdefaultlocale():
+    _locale = locale.setlocale(locale.LC_MESSAGES, None)
+    if _locale == 'C':
+        with _different_locale(''):
+            # The LC_MESSAGES locale does not seem to be configured:
+            # get the user preferred locale.
+            _locale = locale.setlocale(locale.LC_MESSAGES, None)
+    return _locale.split('.')
+
+
 try:
-    LANG = locale.getdefaultlocale()[0]
+    LANG = _getdefaultlocale()[0]
 except ValueError:
     LANG = 'en'
 

--- a/tkfilebrowser/constants.py
+++ b/tkfilebrowser/constants.py
@@ -79,15 +79,20 @@ IM_RECENT = os.path.join(PATH, "images", "recent.png")
 IM_RECENT_24 = os.path.join(PATH, "images", "recent_24.png")
 
 # ---  translation
+def _get_locale_messages_category():
+    try:
+        category = locale.LC_MESSAGES
+    except AttributeError:
+        # LC_MESSAGES may not be available on non-POSIX OSes
+        category = locale.LC_ALL
+    return category
+
+
 class _different_locale:
     def __init__(self, _locale):
         self.locale = _locale
         self.oldlocale = None
-        try:
-            self.category = locale.LC_MESSAGES
-        except AttributeError:
-            # LC_MESSAGES may not be available on non-POSIX OSes
-            self.category = locale.LC_ALL
+        self.category = _get_locale_messages_category()
 
     def __enter__(self):
         self.oldlocale = locale.setlocale(self.category, None)
@@ -100,12 +105,13 @@ class _different_locale:
 
 
 def _getdefaultlocale():
-    _locale = locale.setlocale(self.category, None)
+    category = _get_locale_messages_category()
+    _locale = locale.setlocale(category, None)
     if _locale == 'C':
         with _different_locale(''):
             # The LC_MESSAGES locale does not seem to be configured:
             # get the user preferred locale.
-            _locale = locale.setlocale(self.category, None)
+            _locale = locale.setlocale(category, None)
     return _locale.split('.')
 
 


### PR DESCRIPTION
When tkfilebrowser is used inside a project, the code produces a DeprecationWarning due to the use of locale.getdefaultlocale.

See https://github.com/python/cpython/issues/90817

Solution based on getdefaultlocale's help and CPython's own code in the calendar.LocaleTextCalendar class. Commit:

https://github.com/python/cpython/commit/4fccf910738d1442852cb900747e6dccb8fe03ef